### PR TITLE
fix matplotlib cannot import name _cntr

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   url: https://pypi.io/packages/source/t/tvb-library/{{ name }}-1.5.5.1.tar.gz
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
   skip: True  # [py>27]
 
@@ -28,7 +28,7 @@ requirements:
     - numpy
     - numba
     - numexpr
-    - matplotlib
+    - matplotlib=2.1.2
     - scikit-learn
     - scipy
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - numpy
     - numba
     - numexpr
-    - matplotlib<=2.1.2
+    - matplotlib <=2.1.2
     - scikit-learn
     - scipy
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - numpy
     - numba
     - numexpr
-    - matplotlib>=2.1.2,<2.2.0
+    - matplotlib<=2.1.2
     - scikit-learn
     - scipy
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - numpy
     - numba
     - numexpr
-    - matplotlib=2.1.2
+    - matplotlib>=2.1.2,<2.2.0
     - scikit-learn
     - scipy
 


### PR DESCRIPTION
Fix ImportError: cannot import name _cntr 
because from matplotlib version 2.2.0 no longer support matplotlib._cntr() you have to install matplotlib version 2.1.2